### PR TITLE
Multiplexed networking

### DIFF
--- a/lib/address.js
+++ b/lib/address.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const Multiaddr = require('multiaddr')
+
+class Address {
+
+  constructor (addr) {
+    this._address = addr
+    this._multiAddr = Multiaddr(addr.toString().split('/').slice(0, 5).join('/'))
+  }
+
+  nodeAddress () {
+    return this._multiAddr.nodeAddress()
+  }
+
+  toString () {
+    return this._address
+  }
+
+  toJSON () {
+    return this._address
+  }
+}
+
+module.exports = createAddress
+
+function createAddress (addr) {
+  if (addr instanceof Address) {
+    return addr
+  }
+  return new Address(addr)
+}

--- a/lib/db.js
+++ b/lib/db.js
@@ -17,7 +17,7 @@ class DB {
 
   constructor (_location, id, db, options) {
     this.id = id
-    const dbName = id.replace(/\//g, '_').replace(/\./g, '_')
+    const dbName = id.toString().replace(/\//g, '_').replace(/\./g, '_')
     const leveldown = db || Leveldown
     const location = join(_location, dbName)
     // console.log('location:', location)

--- a/lib/leveldown.js
+++ b/lib/leveldown.js
@@ -6,7 +6,7 @@ const AbstractLevelDown = require('abstract-leveldown').AbstractLevelDOWN
 class LevelDown extends AbstractLevelDown {
 
   constructor (node) {
-    super(node.id)
+    super(node.id.toString())
     this._node = node
   }
 

--- a/lib/multiaddr.js
+++ b/lib/multiaddr.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const Multiaddr = require('multiaddr')
+
+module.exports = Multiaddr

--- a/lib/multiaddr.js
+++ b/lib/multiaddr.js
@@ -1,5 +1,0 @@
-'use strict'
-
-const Multiaddr = require('multiaddr')
-
-module.exports = Multiaddr

--- a/lib/network/active/network.js
+++ b/lib/network/active/network.js
@@ -1,22 +1,24 @@
 'use strict'
 
 const debug = require('debug')('skiff.network.active')
-const Duplex = require('stream').Duplex
+const Writable = require('stream').Writable
 
 const Peer = require('./peer')
+const NetworkNode = require('../network-node')
 
 const defaultOptions = {
   objectMode: true,
   highWaterMark: 50
 }
 
-class Network extends Duplex {
+class Network extends Writable {
 
   constructor (_options) {
     const options = Object.assign({}, _options || {}, defaultOptions)
     debug('creating network with options %j', options)
     super(options)
     this._peers = {}
+    this._nodes = {}
     this._options = options
     this._ended = false
 
@@ -27,6 +29,43 @@ class Network extends Duplex {
     })
   }
 
+  node (address) {
+    let node = this._nodes[address]
+    if (!node) {
+      node = this._nodes[address] = new NetworkNode(address, this, this._options)
+      node.once('finish', () => {
+        node.removeAllListeners()
+        this.removeListener('warning', onWarning)
+        this.removeListener('connect', onConnect)
+        this.removeListener('disconnect', onDisconnect)
+        delete this._nodes[address]
+      })
+      this
+        .on('warning', onWarning)
+        .on('connect', onConnect)
+        .on('disconnect', onDisconnect)
+    }
+    return node
+
+    function onWarning (err, peer) {
+      if (node.match(peer)) {
+        node.emit('warning', err)
+      }
+    }
+
+    function onConnect (peer) {
+      if (node.match(peer)) {
+        node.emit('connect', peer)
+      }
+    }
+
+    function onDisconnect (peer) {
+      if (node.match(peer)) {
+        node.emit('disconnect', peer)
+      }
+    }
+  }
+
   disconnect (address) {
     const peer = this._peers[address]
     if (peer) {
@@ -34,10 +73,6 @@ class Network extends Duplex {
       peer.removeAllListeners()
       delete this._peers[address]
     }
-  }
-
-  _read (size) {
-    // do nothing
   }
 
   _write (message, _, callback) {
@@ -60,7 +95,7 @@ class Network extends Duplex {
       peer = this._peers[address] = new Peer(address, this._options)
       peer
         .on('error', (err) => {
-          this.emit('warning', err)
+          this.emit('warning', err, address)
         })
         .once('finish', () => {
           debug('peer %s closed', address)
@@ -68,7 +103,7 @@ class Network extends Duplex {
         })
         .on('data', (message) => {
           debug('have message from peer: %j', message)
-          this.push(message)
+          this._deliver(message)
         })
         .on('connect', () => {
           this.emit('connect', address)
@@ -82,6 +117,13 @@ class Network extends Duplex {
     }
 
     return peer
+  }
+
+  _deliver (message) {
+    Object.keys(this._nodes)
+      .map(address => this._nodes[address])
+      .filter(node => node.match(message.to))
+      .forEach(node => node.push(message))
   }
 
   peerStats (address) {

--- a/lib/network/active/network.js
+++ b/lib/network/active/network.js
@@ -88,7 +88,8 @@ class Network extends Writable {
     return super.end(buf)
   }
 
-  _ensurePeer (address) {
+  _ensurePeer (_address) {
+    const address = _address.toString()
     debug('ensuring peer %s', address)
     let peer = this._peers[address]
     if (!peer) {

--- a/lib/network/active/peer.js
+++ b/lib/network/active/peer.js
@@ -131,7 +131,7 @@ class Peer extends Duplex {
   _write (message, encoding, callback) {
     debug('writing %j to %s', message, this._address)
 
-    if (! message) {
+    if (!message) {
       return
     }
     if (message.to) {

--- a/lib/network/active/peer.js
+++ b/lib/network/active/peer.js
@@ -3,7 +3,7 @@
 const debug = require('debug')('skiff.network.peer')
 const Duplex = require('stream').Duplex
 const timers = require('timers')
-const Multiaddr = require('multiaddr')
+const Multiaddr = require('../../multiaddr')
 const Msgpack = require('msgpack5')
 
 const reconnect = require('./reconnect')
@@ -136,7 +136,7 @@ class Peer extends Duplex {
         this._stats.lastSent = Date.now()
         this._stats.sentMessageCount ++
       } catch (err) {
-        this.emit('warning', err)
+        this.emit('warning', err, this._address.toString())
       }
     } else {
       debug('have message, but not connected to peer %s', this._address)

--- a/lib/network/active/peer.js
+++ b/lib/network/active/peer.js
@@ -3,9 +3,9 @@
 const debug = require('debug')('skiff.network.peer')
 const Duplex = require('stream').Duplex
 const timers = require('timers')
-const Multiaddr = require('../../multiaddr')
 const Msgpack = require('msgpack5')
 
+const Address = require('../../address')
 const reconnect = require('./reconnect')
 const OK_ERRORS = require('./errors').OK_ERRORS
 
@@ -34,7 +34,7 @@ class Peer extends Duplex {
     const options = Object.assign({}, defaultOptions, _options)
     super(options)
     this._options = options
-    this._address = Multiaddr(address)
+    this._address = Address(address)
 
     this._stats = {
       receivedMessageCount: 0,
@@ -130,6 +130,17 @@ class Peer extends Duplex {
 
   _write (message, encoding, callback) {
     debug('writing %j to %s', message, this._address)
+
+    if (! message) {
+      return
+    }
+    if (message.to) {
+      message.to = message.to.toString()
+    }
+    if (message.from) {
+      message.from = message.from.toString()
+    }
+
     if (this._out) {
       try {
         this._out.write(message, callback)

--- a/lib/network/index.js
+++ b/lib/network/index.js
@@ -5,7 +5,7 @@ const ActiveNetwork = require('./active')
 
 module.exports = createNetwork
 
-function createNetwork(options) {
+function createNetwork (options) {
   return {
     active: new ActiveNetwork(options.active),
     passive: new PassiveNetwork(options.passive)

--- a/lib/network/index.js
+++ b/lib/network/index.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const PassiveNetwork = require('./passive')
+const ActiveNetwork = require('./active')
+
+module.exports = createNetwork
+
+function createNetwork(options) {
+  return {
+    active: new ActiveNetwork(options.active),
+    passive: new PassiveNetwork(options.passive)
+  }
+}

--- a/lib/network/network-node.js
+++ b/lib/network/network-node.js
@@ -7,11 +7,12 @@ class NetworkNode extends Duplex {
 
   constructor (address, out, options) {
     super(options)
-    this._matchAddress = address.split('/')
+    this._matchAddress = address.toString().split('/')
     this._out = out
   }
 
-  match (address) {
+  match (_address) {
+    const address = _address && _address.toString()
     const parts = address && address.split('/')
     const matches = parts && this._matchAddress.every((part, index) => parts[index] === part)
     debug('match %j to own %j. matches: %j', parts, this._matchAddress, matches)

--- a/lib/network/network-node.js
+++ b/lib/network/network-node.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const debug = require('debug')('skiff.network.node')
+const Duplex = require('stream').Duplex
+
+class NetworkNode extends Duplex {
+
+  constructor (address, out, options) {
+    super(options)
+    this._matchAddress = address.split('/')
+    this._out = out
+  }
+
+  match (address) {
+    const parts = address && address.split('/')
+    const matches = parts && this._matchAddress.every((part, index) => parts[index] === part)
+    debug('match %j to own %j. matches: %j', parts, this._matchAddress, matches)
+    return matches
+  }
+
+  _read () {
+    // do nothing
+  }
+
+  _write (message, _, callback) {
+    this._out.write(message, callback)
+  }
+}
+
+module.exports = NetworkNode

--- a/lib/network/passive/network.js
+++ b/lib/network/passive/network.js
@@ -1,10 +1,11 @@
 'use strict'
 
 const debug = require('debug')('skiff.network.passive')
-const Duplex = require('stream').Duplex
+const Writable = require('stream').Writable
 const merge = require('deepmerge')
 
 const Server = require('./server')
+const NetworkNode = require('../network-node')
 
 const defaultOptions = {
   objectMode: true,
@@ -15,26 +16,41 @@ const defaultOptions = {
   }
 }
 
-class Network extends Duplex {
+class Network extends Writable {
 
   constructor (_options) {
     // TODO: merge options.server
     const options = merge(defaultOptions, _options || {})
     debug('creating network with options %j', options)
     super(options)
+    this._nodes = {}
     this._options = options
+    this._listening = false
     this.once('finish', this._finish.bind(this))
     this._listen()
+  }
+
+  node (address) {
+    let node = this._nodes[address]
+    if (!node) {
+      node = this._nodes[address] = new NetworkNode(address, this, this._options)
+      node.once('finish', () => delete this._nodes[address])
+    }
+
+    return node
   }
 
   _listen () {
     debug('network listen()')
     this._server = new Server(this._options.server)
     this._server
-      .once('listening', (options) => this.emit('listening', options))
+      .once('listening', (options) => {
+        this._listening = true
+        this.emit('listening', options)
+      })
       .on('data', message => {
         debug('incoming message from server: %j', message)
-        this.push(message)
+        this._deliver(message)
       })
       .on('warning', warn => this.emit('warning', warn))
       .once('closed', () => {
@@ -42,8 +58,15 @@ class Network extends Duplex {
       })
   }
 
-  _read (size) {
-    // do nothing
+  listening () {
+    return this._listening
+  }
+
+  _deliver (message) {
+    Object.keys(this._nodes)
+      .map(address => this._nodes[address])
+      .filter(node => node.match(message.to))
+      .forEach(node => node.push(message))
   }
 
   _write (message, _, callback) {

--- a/lib/network/passive/network.js
+++ b/lib/network/passive/network.js
@@ -71,6 +71,17 @@ class Network extends Writable {
 
   _write (message, _, callback) {
     debug('writing %j', message)
+
+    if (!message) {
+      return callback()
+    }
+
+    if (message.to) {
+      message.to = message.to.toString()
+    }
+    if (message.from) {
+      message.from = message.from.toString()
+    }
     this._server.write(message, callback)
   }
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -55,6 +55,7 @@ class Node extends EventEmitter {
     this._rpc = RPC(this._stateServices, this.active, this._replies, this, this._options)
 
     this._networkingServices = {
+      id: this.id,
       rpc: this._rpc,
       reply: this._reply.bind(this),
       isMajority: this._isMajority.bind(this),
@@ -176,7 +177,7 @@ class Node extends EventEmitter {
   _reply (to, messageId, params, callback) {
     debug('%s: replying to: %s, messageId: %s, params: %j', this.id, to, messageId, params)
     this.passive.write({
-      to,
+      to: to,
       type: 'reply',
       from: this.id,
       id: messageId,

--- a/lib/rpc.js
+++ b/lib/rpc.js
@@ -7,10 +7,7 @@ const timers = require('timers')
 
 module.exports = function createRPC (node, network, replies, emitter, defaults) {
   return function rpc (options, callback) {
-    debug('%s: rpc to: %s, action: %s, params: %j', this.id, options.to, options.action, options.params)
-    if (typeof options.to !== 'string') {
-      throw new Error('need options.to to be a string')
-    }
+    debug('%s: rpc to: %s, action: %s, params: %j', node.id, options.to, options.action, options.params)
     const term = node.term()
     const done = once(callback)
     const id = uuid()
@@ -20,7 +17,7 @@ module.exports = function createRPC (node, network, replies, emitter, defaults) 
     const started = Date.now()
 
     network.write({
-      from: this.id,
+      from: node.id,
       id,
       type: 'request',
       to: options.to,

--- a/skiff.js
+++ b/skiff.js
@@ -2,12 +2,12 @@
 
 const debug = require('debug')('skiff.node')
 const merge = require('deepmerge')
-const Multiaddr = require('multiaddr')
 const EventEmitter = require('events')
 const async = require('async')
 const join = require('path').join
 const Levelup = require('levelup')
 
+const Address = require('./lib/address')
 const Network = require('./lib/network')
 const IncomingDispatcher = require('./lib/incoming-dispatcher')
 const Node = require('./lib/node')
@@ -47,7 +47,7 @@ class Shell extends EventEmitter {
   constructor (id, _options) {
     debug('creating node %s with options %j', id, _options)
     super()
-    this.id = id
+    this.id = Address(id)
     this._options = merge(defaultOptions, _options || {})
     this._ownsNetwork = false
 
@@ -178,7 +178,7 @@ class Shell extends EventEmitter {
   }
 
   _getNetworkConstructors () {
-    const address = Multiaddr(this.id).nodeAddress()
+    const address = this.id.nodeAddress()
     let constructors = this._options.network
     if (!constructors) {
       this._ownsNetwork = constructors = Network({

--- a/skiff.js
+++ b/skiff.js
@@ -8,8 +8,7 @@ const async = require('async')
 const join = require('path').join
 const Levelup = require('levelup')
 
-const PassiveNetwork = require('./lib/network/passive')
-const ActiveNetwork = require('./lib/network/active')
+const Network = require('./lib/network')
 const IncomingDispatcher = require('./lib/incoming-dispatcher')
 const Node = require('./lib/node')
 const CommandQueue = require('./lib/command-queue')
@@ -50,6 +49,7 @@ class Shell extends EventEmitter {
     super()
     this.id = id
     this._options = merge(defaultOptions, _options || {})
+    this._ownsNetwork = false
 
     this._db = new DB(this._options.location, this.id, this._options.db, this._options.levelup)
 
@@ -145,27 +145,11 @@ class Shell extends EventEmitter {
   }
 
   _startNetwork (cb) {
-    const address = Multiaddr(this.id).nodeAddress()
-    const passiveNetworkOptions = {
-      server: merge(
-        {
-          port: address.port,
-          host: address.address
-        },
-        this._options.server)
-    }
-    debug('about to configure passive network for %s with options %j', this.id, passiveNetworkOptions)
-    const passiveNetwork = new PassiveNetwork(passiveNetworkOptions)
-
-    if (cb) {
-      passiveNetwork.once('listening', () => {
-        cb()
-      }) // do not carry event args into callback
-    }
+    const network = this._getNetworkConstructors()
 
     this._network = {
-      passive: passiveNetwork,
-      active: new ActiveNetwork()
+      passive: network.passive.node(this.id),
+      active: network.active.node(this.id)
     }
 
     this._network.passive.pipe(this._dispatcher, { end: false })
@@ -180,6 +164,37 @@ class Shell extends EventEmitter {
     this._network.active.on('disconnect', peer => {
       this.emit('disconnect', peer)
     })
+
+    if (cb) {
+      if (network.passive.listening) {
+        process.nextTick(cb)
+      } else {
+        network.passive.once('listening', () => {
+          cb() // do not carry event args into callback
+        })
+      }
+    }
+
+  }
+
+  _getNetworkConstructors () {
+    const address = Multiaddr(this.id).nodeAddress()
+    let constructors = this._options.network
+    if (!constructors) {
+      this._ownsNetwork = constructors = Network({
+        passive: {
+          server: merge(
+            {
+              port: address.port,
+              host: address.address
+            },
+            this._options.server
+          )
+        }
+      })
+    }
+
+    return constructors
   }
 
   _loadPersistedState (cb) {
@@ -205,7 +220,13 @@ class Shell extends EventEmitter {
   stop (cb) {
     if (this._network) {
       if (cb) {
-        this._network.passive.once('closed', cb)
+        if (this._ownsNetwork) {
+          this._ownsNetwork.passive.once('closed', cb)
+          this._ownsNetwork.passive.end()
+          this._ownsNetwork.active.end()
+        } else {
+          process.nextTick(cb)
+        }
       }
       this._network.passive.end()
       this._network.active.end()

--- a/skiff.js
+++ b/skiff.js
@@ -174,7 +174,6 @@ class Shell extends EventEmitter {
         })
       }
     }
-
   }
 
   _getNetworkConstructors () {

--- a/test.js
+++ b/test.js
@@ -1,0 +1,3 @@
+M = require('./lib/multiaddr')
+m = M('/ip4/127.0.0.1/tcp/123/user/abc')
+console.log(m.toString())

--- a/test/active-network.js
+++ b/test/active-network.js
@@ -7,7 +7,7 @@ const it = lab.it
 const expect = require('code').expect
 
 const async = require('async')
-const Multiaddr = require('multiaddr')
+const Address = require('../lib/address')
 const net = require('net')
 const timers = require('timers')
 const Msgpack = require('msgpack5')
@@ -15,9 +15,9 @@ const Msgpack = require('msgpack5')
 const Network = require('../lib/network/active')
 
 const serverAddresses = [
-  '/ip4/127.0.0.1/tcp/8080',
-  '/ip4/127.0.0.1/tcp/8081',
-  '/ip4/127.0.0.1/tcp/8082'
+  '/ip4/127.0.0.1/tcp/8080/what/ever',
+  '/ip4/127.0.0.1/tcp/8081/what/ever',
+  '/ip4/127.0.0.1/tcp/8082/what/ever'
 ]
 
 const A_BIT = 500
@@ -48,7 +48,7 @@ describe('active network', () => {
 
     async.mapSeries(serverAddresses, (addr, cb) => {
       const index = ++lindex
-      const maddr = Multiaddr(addr)
+      const maddr = Address(addr)
       const server = net.createServer(onServerConnection)
       const listenAddr = maddr.nodeAddress()
       server.listen({port: listenAddr.port, host: listenAddr.address}, () => {

--- a/test/active-network.js
+++ b/test/active-network.js
@@ -77,11 +77,12 @@ describe('active network', () => {
   })
 
   it('can be used to send a message to a peer', done => {
-    network.once('data', message => {
+    const node = network.node(serverAddresses[0])
+    node.once('data', message => {
       expect(message).to.equal({to: serverAddresses[0], what: 'hey', isReply: true})
       done()
     })
-    network.write({to: serverAddresses[0], what: 'hey'})
+    node.write({to: serverAddresses[0], what: 'hey'})
   })
 
   it('peer gets the message', done => {
@@ -108,7 +109,8 @@ describe('active network', () => {
   })
 
   it('can still send data to another peer', done => {
-    network.once('data', message => {
+    const node = network.node(serverAddresses[1])
+    node.once('data', message => {
       expect(message).to.equal({to: serverAddresses[1], what: 'hey you', isReply: true})
       done()
     })
@@ -120,11 +122,12 @@ describe('active network', () => {
   })
 
   it('can still send data to another peer 2', done => {
-    network.once('data', message => {
+    const node = network.node(serverAddresses[2])
+    node.once('data', message => {
       expect(message).to.equal({to: serverAddresses[2], what: 'hey you dude', isReply: true})
       done()
     })
-    network.write({to: serverAddresses[2], what: 'hey you dude'})
+    node.write({to: serverAddresses[2], what: 'hey you dude'})
   })
 
   it('peer gets the message', done => {
@@ -133,11 +136,12 @@ describe('active network', () => {
   })
 
   it('can send data to reconnected peer', done => {
-    network.once('data', message => {
+    const node = network.node(serverAddresses[0])
+    node.once('data', message => {
       expect(message).to.equal({to: serverAddresses[0], what: 'hey you\'re back!', isReply: true})
       done()
     })
-    network.write({to: serverAddresses[0], what: 'hey you\'re back!'})
+    node.write({to: serverAddresses[0], what: 'hey you\'re back!'})
   })
 
   it('reconnected peer gets the message', done => {


### PR DESCRIPTION
Allows a peer address to me more than a network address. Example: `/ip4/127.0.01/tcp/123/foo/bar`. This allows having virtual nodes inside the same process, sharing the same network.